### PR TITLE
Use STRR and STRL

### DIFF
--- a/include/sq2_ccv2/ccv2_teleoperator.h
+++ b/include/sq2_ccv2/ccv2_teleoperator.h
@@ -41,6 +41,7 @@ private:
     double MAX_PITCH_ANGLE;
     double MAX_ROLL_ANGLE;
     double PITCH_OFFSET;
+    double TREAD;
 
     ros::NodeHandle nh;
     ros::NodeHandle local_nh;


### PR DESCRIPTION
`servo::STRR` and `servo::STRL` are used instead of `servo::STEER`

**not tested on the real robot yet**